### PR TITLE
Add Soul (ANSI) layout for AutoHotkey

### DIFF
--- a/downloads/Soul_ansi.ahk
+++ b/downloads/Soul_ansi.ahk
@@ -1,0 +1,35 @@
+; Soul mapping for ANSI boards
+
+;SC010::q
+;SC011::w
+SC012::l
+SC013::d
+SC014::p
+SC015::k
+SC016::m
+SC017::u
+SC018::y
+SC019::;
+
+;SC01E::a
+SC01F::s
+SC020::r
+SC021::t
+;SC022::g
+SC023::f
+SC024::n
+SC025::e
+SC026::i
+SC027::o
+
+;SC02c::z
+;SC02d::x
+;SC02e::c
+;SC02f::v
+SC030::j
+SC031::b
+SC032::h
+
+; set Backspace to CapsLock key
+
+; sc03a::backspace


### PR DESCRIPTION
Based on the Colemak-DH layout:
https://github.com/ColemakMods/mod-dh/blob/master/autohotkey/colemak_dh_ansi.ahk
for AutoHotkey
https://www.autohotkey.com/

Once AutoHotkey is installed, simply double clicking the `.ahk` file enables the keyboard and adds a tray icon (on Windows at least) for managing the script and its state.

Provides an alternative to the Microsoft KLC approach.